### PR TITLE
Update code to reflect networking/v1beta1 scheme

### DIFF
--- a/general-app-services/nginx-ingress-controller/index.ts
+++ b/general-app-services/nginx-ingress-controller/index.ts
@@ -71,7 +71,7 @@ const service = new k8s.core.v1.Service(name,
 export const serviceName = service.metadata.name;
 
 // Create the kuard Ingress
-const ingress = new k8s.extensions.v1beta1.Ingress(name,
+const ingress = new k8s.networking.v1.Ingress(name,
     {
         metadata: {
             labels: labels,
@@ -86,9 +86,12 @@ const ingress = new k8s.extensions.v1beta1.Ingress(name,
                         paths: [
                             {
                                 path: "/",
+                                pathType: "ImplementationSpecific",
                                 backend: {
-                                    serviceName: serviceName,
-                                    servicePort: "http",
+                                    service: {
+                                        name: serviceName,
+                                        port: "http"
+                                    }
                                 }
                             },
                         ],


### PR DESCRIPTION
The provider was updated: https://github.com/pulumi/pulumi-kubernetes/pull/1221

Using the previous Ingress scheme caused an error, as the await logic is expecting extensions/v1beta1/Ingress and it was not able to find the endpoint associated with the service name.