### PR TITLE
Fix confusing container name

### DIFF
--- a/general-cluster-services/datadog-daemonset/index.ts
+++ b/general-cluster-services/datadog-daemonset/index.ts
@@ -99,7 +99,7 @@ const datadog = new k8s.apps.v1.DaemonSet(appName, {
                 containers: [
                     {
                         image: "datadog/agent:latest",
-                        name: "nginx",
+                        name: "datadog",
                         resources: {limits: {memory: "512Mi"}, requests: {memory: "512Mi"}},
                         env: [
                             {


### PR DESCRIPTION
Hello,

I am sorry if this PR is out of your standards, but I could not find a guide on how to contribute.

The naming of the DataDog example container is set to `nginx`. I thing that this is somewhat confusing, since it does not seems to be related with `nginx` at all.

I instead named the container as `datadog`.

Hope it makes sense.