### PR TITLE
Helm version and Ingress fix

### DIFF
--- a/aws/04-cluster-services/index.ts
+++ b/aws/04-cluster-services/index.ts
@@ -39,7 +39,7 @@ attachLogPolicies("perfRpa", perfNodegroupIamRoleName);
 const provider = new k8s.Provider("provider", {kubeconfig: config.kubeconfig});
 const fluentdCloudWatchLogGroup = new aws.cloudwatch.LogGroup(name);
 export let fluentdCloudWatchLogGroupName = fluentdCloudWatchLogGroup.name;
-const fluentdCloudwatch = new k8s.helm.v2.Chart(name,
+const fluentdCloudwatch = new k8s.helm.v3.Chart(name,
     {
         namespace: config.clusterSvcsNamespaceName,
         chart: "fluentd-cloudwatch",

--- a/general-app-services/nginx-ingress-controller/index.ts
+++ b/general-app-services/nginx-ingress-controller/index.ts
@@ -9,7 +9,7 @@ const provider = new k8s.Provider("provider", {
 export const appsNamespaceName = config.appsNamespaceName
 
 // Deploy NGINX ingress controller using the Helm chart.
-const nginx = new k8s.helm.v2.Chart("nginx",
+const nginx = new k8s.helm.v3.Chart("nginx",
     {
         namespace: config.appSvcsNamespaceName,
         chart: "nginx-ingress",
@@ -90,7 +90,9 @@ const ingress = new k8s.networking.v1.Ingress(name,
                                 backend: {
                                     service: {
                                         name: serviceName,
-                                        port: "http"
+                                        port: {
+                                            name: "http",
+                                        }
                                     }
                                 }
                             },


### PR DESCRIPTION
As pointed in our [documentation](https://www.pulumi.com/docs/guides/crosswalk/kubernetes/app-services/#nginx-ingress-controller), we use `new k8s.helm.v3.Chart(...);`. However, the code in this guide uses `new k8s.helm.v2.Chart(...);`.

This PR calls `k8s.helm.v3.Chart()` where applicable and updates how the back-end service port is set.